### PR TITLE
fix: post-mergeスクリプトのマイグレーション検出パターン改善

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -20,7 +20,7 @@ if echo "$changed_files" | grep -q "package.json\|pnpm-lock.yaml"; then
 fi
 
 # マイグレーションファイルの変更を検出
-if echo "$changed_files" | grep -q "migrations\|schema.sql\|db/schema"; then
+if echo "$changed_files" | grep -q "migrations\|schema.sql\|db/schema\|migrate.js\|database-migration"; then
   echo "💾 データベーススキーマの変更を検出しました"
 
   # package.jsonでマイグレーションコマンドを確認
@@ -94,8 +94,8 @@ echo ""
 echo "対応が必要な可能性のあるアクション:"
 [ "$test_result" -ne 0 ] && echo "- テスト失敗の修正"
 echo "$changed_files" | grep -q "package.json" && echo "- 新しい依存関係の確認"
-echo "$changed_files" | grep -q "migrations" && echo "- データベースマイグレーションの確認"
-echo "$changed_files" | grep -q ".env.example" && echo "- 環境変数の更新"
+echo "$changed_files" | grep -q "migrations\|schema.sql\|db/schema\|migrate.js\|database-migration" && echo "- データベースマイグレーションの確認"
+echo "$changed_files" | grep -q ".env.example\|.env.template" && echo "- 環境変数の更新"
 
 echo "✅ マージ後の処理が完了しました！"
 exit 0

--- a/fix_post_merge.sh
+++ b/fix_post_merge.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# マイグレーションファイルのパターンを修正する
+sed -i "" "s/migrations\\|schema.sql\\|db\\/schema/migrations\\|schema.sql\\|db\\/schema\\|migrate.js\\|database-migration/g" .husky/post-merge
+
+echo "post-mergeスクリプトのパターンを更新しました"


### PR DESCRIPTION
## 概要
post-mergeスクリプトのマイグレーション検出パターンを改善し、migrate.jsやdatabase-migrationのような関連ファイルも検出できるようにしました。

## 変更内容
- マイグレーション検出パターンに `migrate.js` と `database-migration` を追加
- 要約表示部分のパターンも同様に更新

## 変更理由
最近のプルリクエスト（#16）で `.github/workflows/database-migration.yml` と `scripts/migrate.js` が変更されましたが、これらのファイルが現行のパターンでは検出されず、マイグレーション処理が実行されませんでした。

## テスト
- 修正用スクリプトを作成し、正常にパターンが更新されることを確認しました
- grep コマンドで確認し、更新後のパターンが反映されていることを確認しました
