### PR TITLE
fix: post-mergeスクリプトを非対話モードで実行するように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ github-actions-reports/
 # tsconfig.json
 # wrangler.toml
 # .env.example
+
+# テスト結果
+junit.xml

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -42,15 +42,17 @@ fi
 
 # テストフレームワークの検出
 echo "🧪 テストを実行中..."
+# 非対話モードを強制するためのCI環境変数を設定
+export CI=true
 if grep -q "\"test:all\"" package.json; then
-  pnpm test:all
+  pnpm test:all --run
   test_result=$?
 elif grep -q "\"test:integration\"" package.json; then
-  pnpm test:integration
+  pnpm test:integration --run
   test_result=$?
 else
-  # デフォルトのテストコマンド
-  pnpm test
+  # デフォルトのテストコマンド - 非対話モードで実行するためのフラグを追加
+  pnpm test --run
   test_result=$?
 fi
 


### PR DESCRIPTION
## 変更内容
- post-mergeフック内のテスト実行コマンドを非対話モードで実行するように修正
- テスト実行時に`--run`フラグを追加して、ウォッチモードを無効化
- `CI=true`環境変数を設定して、完全な非対話モードを強制
- テスト結果ファイル(junit.xml)を.gitignoreに追加

## 修正理由
マージ後のフック実行時に、テストコマンドがウォッチモードで実行され、ユーザー入力を待機したままスクリプトが停止する問題を修正。これにより、マージ後の処理が自動的に最後まで完了するようになります。

## テスト結果
- ローカルで動作確認済み
- テスト実行後に自動的に次のステップに進む